### PR TITLE
Move viewer into its own component that maintains its own internal state

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -28,7 +28,7 @@ COPY web /web
 WORKDIR /web
 RUN npm install && npm run dev
 
-RUN git clone https://github.com/StackStorm/orquesta.git /orquesta
+COPY orquesta /orquesta
 WORKDIR /orquesta
 RUN pip install -e .
 

--- a/image/web/src/Editor.jsx
+++ b/image/web/src/Editor.jsx
@@ -8,47 +8,15 @@ import AceEditor from 'react-ace';
 import 'brace/mode/yaml';
 import 'brace/theme/github';
 
-import { Graphviz } from 'graphviz-react';
+import Orquesta from './components/Orquesta.jsx';
 
 class EditorView extends React.Component {
-
 
     constructor(props) {
         super(props);
         this.state = {
-            error: '',
-            yamlSource: '',
-            graphVizSource: null
+            yamlSource: ''
         };
-        this.updateGraph = this.updateGraph.bind(this)
-    }
-
-    updateGraph(newYAML) {
-        this.setState({ yamlSource: newYAML });
-        var payload = {
-            "wf_def": newYAML
-        }
-        var json_payload = JSON.stringify(payload)
-
-        var uri = new URI(this.props.uri)
-        fetch(uri, {
-            headers: new Headers({
-                'Content-Type' : 'application/json'
-            }),
-            method: 'post',
-            body: json_payload})
-            .then(res => res.json())
-            .then(
-                (result) => {
-                    //return result value here
-                    if ('error' in result) {
-                        this.setState({ error: result['error'], graphVizSource: null });
-                    } else if ('agraph_string' in result) {
-
-                        this.setState({ error: null, graphVizSource: result['agraph_string'] });
-                    }
-                }
-            )
     }
 
     render() {
@@ -61,7 +29,7 @@ class EditorView extends React.Component {
                             value={this.state.yamlSource}
                             mode="yaml"
                             theme="github"
-                            onChange={(newYAML) => {this.updateGraph(newYAML)}}
+                            onChange={(newYAML) => {this.setState({ yamlSource: newYAML })}}
                             debounceChangePeriod={750}
                             name="uid"
                             editorProps={{$blockScrolling: true}}
@@ -73,24 +41,12 @@ class EditorView extends React.Component {
                     </div>
 
                     <div className="col-8">
-                        {this.state.error == null &&
-                                <Graphviz
-                                    dot={this.state.graphVizSource}
-                                    options={{'height': 1000, 'width': '100%', 'zoom': true}}
-                                />
-                        }
-                        {this.state.graphVizSource == null &&
-                                <p>{this.state.error}</p>
-                        }
+                        <Orquesta yaml={this.state.yamlSource} />
                     </div>
                 </div>
             </div>
         );
     }
-}
-
-EditorView.defaultProps= {
-    uri: "/create_graph"
 }
 
 var container = document.getElementById('container');

--- a/image/web/src/components/Orquesta.jsx
+++ b/image/web/src/components/Orquesta.jsx
@@ -17,6 +17,10 @@ class Orquesta extends React.Component {
     }
 
     fetchDotAndUpdateState(yaml) {
+        if(yaml === ''){
+            this.setState({ error: '', dot: null });
+            return;
+        }
         const json_payload = JSON.stringify({
             "wf_def": yaml
         });

--- a/image/web/src/components/Orquesta.jsx
+++ b/image/web/src/components/Orquesta.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import URI from "urijs";
+
+import { Graphviz } from 'graphviz-react';
+
+
+class Orquesta extends React.Component {
+
+    constructor(props) {
+        super(props);
+        this.state = {
+            error: '',
+            dot: null,
+        };
+        this.fetchDotAndUpdateState = this.fetchDotAndUpdateState.bind(this);
+    }
+
+    fetchDotAndUpdateState(yaml) {
+        const json_payload = JSON.stringify({
+            "wf_def": yaml
+        });
+
+        const uri = new URI("/create_graph");
+        fetch(uri, {
+            headers: new Headers({
+                'Content-Type' : 'application/json'
+            }),
+            method: 'post',
+            body: json_payload})
+            .then(res => res.json())
+            .then(
+                (result) => {
+                    if ('error' in result) {
+                        this.setState({ error: result['error'], dot: null });
+                    } else if ('agraph_string' in result) {
+                        this.setState({ error: null, dot: result['agraph_string'] });
+                    }
+                }
+            )
+    }
+
+    componentDidMount() {
+        this.fetchDotAndUpdateState(this.props.yaml);
+    }
+
+    componentDidUpdate(prevProps) {
+        if (this.props.yaml !== prevProps.yaml) {
+            this.fetchDotAndUpdateState(this.props.yaml);
+        }
+    }
+
+    render() {
+        if(this.state.error === null) {
+            return (
+                <Graphviz
+                    dot={this.state.dot}
+                    options={{'height': 1000, 'width': '100%', 'zoom': true}}
+                />
+            )
+        }
+        else if (this.state.dot === null) {
+            return <p>{this.state.error}</p>
+        }
+    }
+}
+
+export default Orquesta;


### PR DESCRIPTION
Previously the delay in server side computation of the graph and component re-render would result in the editing experience being subpar.  This has been fixed by moving the dot source into the state of a separate component.  This prevents the editor from rendering over whatever the user is typing.