### PR TITLE
make up fails as ":dev" tag not on docker hub

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   rehearsal:
-    image: trstruth/rehearsal:dev
+    image: trstruth/rehearsal:latest
     container_name: rehearsal
     ports:
      - "5000:5000"


### PR DESCRIPTION
Single change to the tag from :dev to :latest which is present on this projects docker hub page.

make up now works after clone instructions from the readme.